### PR TITLE
Enforced all generated Hashes being lowercase

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -15,7 +15,7 @@ function cryptoStr(length) {
     .replace(/\+/g, "0")
     .replace(/\//g, "0");
 
-  return randomString;
+  return randomString.toLowerCase();
 }
 
 module.exports = cryptoStr;


### PR DESCRIPTION
Modified the result from our Hashing Function since it caused a mismatch when querying the database.